### PR TITLE
Handle XML special characters in contact names etc.

### DIFF
--- a/src/de/shandschuh/slightbackup/Strings.java
+++ b/src/de/shandschuh/slightbackup/Strings.java
@@ -28,12 +28,18 @@ package de.shandschuh.slightbackup;
 public final class Strings {
 	public static final String BODY = "body";
 	
-	public static final String LT = "&lt;";
+	public static final String[] QUOT = {"\"", "&quot;"};
+
+	public static final String[] AMP = {"&", "&amp;"};
+
+	public static final String[] APOS = {"'", "&apos;"};
 	
-	public static final String GT = "&gt;";
+	public static final String[] LT = {"<", "&lt;"};
 	
-	public static final String AMP = "&amp;";
+	public static final String[] GT = {">", "&gt;"};
 	
+	public static final String[][] XML_entities = { AMP, QUOT, APOS, LT, GT };
+		
 	public static final String TAG_MESSAGE = "message";
 	
 	public static final String TAG_CALL = "call";
@@ -112,5 +118,11 @@ public final class Strings {
     	}
     	return -1;
     }
-	
+
+	public static String sanitize(String string) {
+		for (String[] entity : XML_entities) {
+			string = string.replace(entity[0], entity[1]);
+		}
+		return string;
+	}
 }

--- a/src/de/shandschuh/slightbackup/exporter/SimpleExporter.java
+++ b/src/de/shandschuh/slightbackup/exporter/SimpleExporter.java
@@ -40,8 +40,6 @@ import de.shandschuh.slightbackup.R;
 import de.shandschuh.slightbackup.Strings;
 
 public abstract class SimpleExporter extends Exporter {
-	private static final String REALAMP = "&";
-	
 	protected static final String EQUALS = "=\"";
 	
 	protected Context context;
@@ -149,7 +147,7 @@ public abstract class SimpleExporter extends Exporter {
             			if (index1 > -1 && index2 > index1) {
             				writer.write(string.substring(index1+1, index2));
             			} else {
-            				writer.write(string.replace(REALAMP, Strings.AMP));
+            				writer.write(Strings.sanitize(string));
             			}
             			writer.write('"');
         			}


### PR DESCRIPTION
After exporting call log with contact having quotes(") in it's name or other XML special character import would fail. Manually changing every character to its entity reference fixed the import.

To fix the problem I changed the export class to replace all special characters with its entity reference.
## 

Regards
Maciej Sitarz
